### PR TITLE
Enable hibernation support, set UI scale nicely, fix validation

### DIFF
--- a/EFI/OC/config_easy.plist
+++ b/EFI/OC/config_easy.plist
@@ -144,8 +144,6 @@
             </array>
             <key>Quirks</key>
             <dict>
-                <key>EnableForAll</key>
-                <false/>
                 <key>FadtEnableReset</key>
                 <false/>
                 <key>NormalizeHeaders</key>
@@ -179,8 +177,6 @@
                 <key>DisableVariableWrite</key>
                 <false/>
                 <key>DiscardHibernateMap</key>
-                <false/>
-                <key>EnableForAll</key>
                 <false/>
                 <key>EnableSafeModeSlide</key>
                 <true/>
@@ -882,9 +878,9 @@
                 <key>ConsoleAttributes</key>
                 <integer>0</integer>
                 <key>HibernateMode</key>
-                <string>None</string>
+                <string>NVRAM</string>
                 <key>HibernateSkipsPicker</key>
-                <false/>
+                <true/>
                 <key>HideAuxiliary</key>
                 <true/>
                 <key>InstanceIdentifier</key>
@@ -905,8 +901,6 @@
                 <false/>
                 <key>ShowPicker</key>
                 <true/>
-                <key>SkipCustomEntryCheck</key>
-                <false/>
                 <key>TakeoffDelay</key>
                 <integer>0</integer>
                 <key>Timeout</key>
@@ -958,7 +952,7 @@
                 <key>ScanPolicy</key>
                 <integer>0</integer>
                 <key>SecureBootModel</key>
-                <string>Default</string>
+                <string>Disabled</string>
                 <key>Vault</key>
                 <string>Optional</string>
             </dict>
@@ -1424,7 +1418,7 @@ en-US:0</string>
                 <key>TextRenderer</key>
                 <string>BuiltinGraphics</string>
                 <key>UIScale</key>
-                <integer>0</integer>
+                <integer>2</integer>
                 <key>UgaPassThrough</key>
                 <false/>
             </dict>

--- a/EFI/OC/config_hard.plist
+++ b/EFI/OC/config_hard.plist
@@ -144,8 +144,6 @@
             </array>
             <key>Quirks</key>
             <dict>
-                <key>EnableForAll</key>
-                <false/>
                 <key>FadtEnableReset</key>
                 <false/>
                 <key>NormalizeHeaders</key>
@@ -179,8 +177,6 @@
                 <key>DisableVariableWrite</key>
                 <false/>
                 <key>DiscardHibernateMap</key>
-                <false/>
-                <key>EnableForAll</key>
                 <false/>
                 <key>EnableSafeModeSlide</key>
                 <true/>
@@ -876,9 +872,9 @@
                 <key>ConsoleAttributes</key>
                 <integer>0</integer>
                 <key>HibernateMode</key>
-                <string>None</string>
+                <string>NVRAM</string>
                 <key>HibernateSkipsPicker</key>
-                <false/>
+                <true/>
                 <key>HideAuxiliary</key>
                 <true/>
                 <key>InstanceIdentifier</key>
@@ -899,8 +895,6 @@
                 <false/>
                 <key>ShowPicker</key>
                 <true/>
-                <key>SkipCustomEntryCheck</key>
-                <false/>
                 <key>TakeoffDelay</key>
                 <integer>0</integer>
                 <key>Timeout</key>
@@ -952,7 +946,7 @@
                 <key>ScanPolicy</key>
                 <integer>0</integer>
                 <key>SecureBootModel</key>
-                <string>Default</string>
+                <string>Disabled</string>
                 <key>Vault</key>
                 <string>Optional</string>
             </dict>
@@ -1418,7 +1412,7 @@ en-US:0</string>
                 <key>TextRenderer</key>
                 <string>BuiltinGraphics</string>
                 <key>UIScale</key>
-                <integer>0</integer>
+                <integer>2</integer>
                 <key>UgaPassThrough</key>
                 <false/>
             </dict>


### PR DESCRIPTION
## Hibernation

With this PR + a few commands, hibernation should be enabled. Fixes #3 

After updating `config.plist`, run the following:

```
sudo pmset -a sleep 1;
sudo pmset -a hibernatemode 25;
sudo pmset -a disablesleep 0;
sudo pmset restoredefaults;
```

Reboot, then close the cover on your Surface. Wait about 30-40 seconds, then open the cover back up. Press the power button for like 1-2 seconds, and you'll see the Windows logo. Within about 13 seconds of pressing the power button, it should restore from hibernation, skipping OC completely.

## UIScale

The default UI scale looks way too tiny on the Surface Go 2. Changing it to `2` makes it more closely match the hi-DPI look.

## Schema validation errors

After opening this up in OCAuxiliaryTools with 0.9.7 loaded, I found `ocvalidate` reported some schema errors. This PR fixes those schema errors by removing the items that are no longer valid.